### PR TITLE
adding set-default method, use logger name as context

### DIFF
--- a/encoder_device.go
+++ b/encoder_device.go
@@ -1,142 +1,14 @@
 package sszap
 
 import (
-	"time"
-
-	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
 )
-
-type deviceEventEncoder struct {
-	*zapcore.EncoderConfig
-	internal zapcore.Encoder
-}
-
-func (enc deviceEventEncoder) AddArray(key string, arr zapcore.ArrayMarshaler) error {
-	return enc.internal.AddArray(key, arr)
-}
-
-func (enc deviceEventEncoder) AddObject(key string, obj zapcore.ObjectMarshaler) error {
-	return enc.internal.AddObject(key, obj)
-}
-
-func (enc deviceEventEncoder) AddBinary(key string, val []byte) {
-	enc.internal.AddBinary(key, val)
-}
-
-func (enc deviceEventEncoder) AddByteString(key string, val []byte) {
-	enc.internal.AddByteString(key, val)
-}
-
-func (enc deviceEventEncoder) AddBool(key string, val bool) {
-	enc.internal.AddBool(key, val)
-}
-
-func (enc deviceEventEncoder) AddComplex128(key string, val complex128) {
-	enc.internal.AddComplex128(key, val)
-}
-
-func (enc deviceEventEncoder) AddComplex64(key string, val complex64) {
-	enc.internal.AddComplex64(key, val)
-}
-
-func (enc deviceEventEncoder) AddDuration(key string, val time.Duration) {
-	enc.internal.AddDuration(key, val)
-}
-
-func (enc deviceEventEncoder) AddFloat64(key string, val float64) {
-	enc.internal.AddFloat64(key, val)
-}
-
-func (enc deviceEventEncoder) AddFloat32(key string, val float32) {
-	enc.internal.AddFloat32(key, val)
-}
-
-func (enc deviceEventEncoder) AddInt(key string, val int) {
-	enc.internal.AddInt(key, val)
-}
-
-func (enc deviceEventEncoder) AddInt64(key string, val int64) {
-	enc.internal.AddInt64(key, val)
-}
-
-func (enc deviceEventEncoder) AddInt32(key string, val int32) {
-	enc.internal.AddInt32(key, val)
-}
-
-func (enc deviceEventEncoder) AddInt16(key string, val int16) {
-	enc.internal.AddInt16(key, val)
-}
-
-func (enc deviceEventEncoder) AddInt8(key string, val int8) {
-	enc.internal.AddInt8(key, val)
-}
-
-func (enc deviceEventEncoder) AddString(key, val string) {
-	enc.internal.AddString(key, val)
-}
-
-func (enc deviceEventEncoder) AddTime(key string, val time.Time) {
-	enc.internal.AddTime(key, val)
-}
-
-func (enc deviceEventEncoder) AddUint(key string, val uint) {
-	enc.internal.AddUint(key, val)
-}
-
-func (enc deviceEventEncoder) AddUint64(key string, val uint64) {
-	enc.internal.AddUint64(key, val)
-}
-
-func (enc deviceEventEncoder) AddUint32(key string, val uint32) {
-	enc.internal.AddUint32(key, val)
-}
-
-func (enc deviceEventEncoder) AddUint16(key string, val uint16) {
-	enc.internal.AddUint16(key, val)
-}
-
-func (enc deviceEventEncoder) AddUint8(key string, val uint8) {
-	enc.internal.AddUint8(key, val)
-}
-
-func (enc deviceEventEncoder) AddUintptr(key string, val uintptr) {
-	enc.internal.AddUintptr(key, val)
-}
-
-func (enc deviceEventEncoder) AddReflected(key string, val interface{}) error {
-	return enc.internal.AddReflected(key, val)
-}
-
-func (enc deviceEventEncoder) OpenNamespace(key string) {
-	enc.internal.OpenNamespace(key)
-}
-
-func (enc deviceEventEncoder) Clone() zapcore.Encoder {
-	return deviceEventEncoder{
-		EncoderConfig: enc.EncoderConfig,
-		internal:      enc.internal.Clone(),
-	}
-}
-
-func (enc deviceEventEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
-	fields = append(fields, ContextField())
-
-	return enc.internal.EncodeEntry(ent, fields)
-}
-
-func newDeviceEventEncoder(cfg zapcore.EncoderConfig) zapcore.Encoder {
-	return deviceEventEncoder{
-		EncoderConfig: &cfg,
-		internal:      zapcore.NewJSONEncoder(cfg),
-	}
-}
 
 func newDeviceEventEncoderConfig() zapcore.EncoderConfig {
 	return zapcore.EncoderConfig{
 		TimeKey:        "date_time",
 		LevelKey:       "level",
-		NameKey:        zapcore.OmitKey,
+		NameKey:        "context",
 		CallerKey:      zapcore.OmitKey,
 		FunctionKey:    zapcore.OmitKey,
 		MessageKey:     "event_message",

--- a/encoder_stdout.go
+++ b/encoder_stdout.go
@@ -158,7 +158,7 @@ func newStdoutEncoderConfig() zapcore.EncoderConfig {
 	return zapcore.EncoderConfig{
 		TimeKey:        "timestamp",
 		LevelKey:       "severity",
-		NameKey:        zapcore.OmitKey,
+		NameKey:        "context",
 		CallerKey:      zapcore.OmitKey,
 		FunctionKey:    zapcore.OmitKey,
 		MessageKey:     "text_payload",

--- a/examples/example.go
+++ b/examples/example.go
@@ -9,16 +9,15 @@ import (
 func simpleLogger() { //nolint
 	logLevel := "debug"
 
-	sszap.InitLogger(
+	logger := sszap.NewLogger(
 		sszap.NewPreparedStdoutCore(logLevel),
 	)
+	sszap.SetDefaultLogger(logger.Named("test"))
 
 	ctx := context.Background()
+	ctxLogger := sszap.FromContext(ctx)
 
-	logger := sszap.FromContext(ctx)
-
-	logger.With(
+	ctxLogger.With(
 		sszap.DeviceIDField("test_id"),
 	).Info("New info message")
-
 }

--- a/examples/syncer_example.go
+++ b/examples/syncer_example.go
@@ -26,15 +26,16 @@ func (ws *eWriteSyncer) Sync() error {
 func deviceLogger() { //nolint
 	logLevel := "debug"
 
-	sszap.InitLogger(
+	logger := sszap.NewLogger(
 		sszap.NewPreparedDeviceCore(logLevel, &eWriteSyncer{}),
 	)
+	sszap.SetDefaultLogger(logger)
 
 	ctx := context.Background()
 
-	logger := sszap.FromContext(ctx)
+	ctxLogger := sszap.FromContext(ctx)
 
-	logger.With(
+	ctxLogger.With(
 		sszap.DeviceIDField("test_id"),
 	).Info("New info message")
 

--- a/fields_common.go
+++ b/fields_common.go
@@ -6,13 +6,10 @@ import (
 )
 
 const (
-	contextName = "api"
-
 	deviceIDKey  = "device_id"
 	eventKey     = "event"
 	eventCodeKey = "event_code"
 	dataKey      = "data"
-	contextKey   = "context"
 	sourceKey    = "source_location"
 )
 
@@ -26,10 +23,6 @@ func EventField(e string) zapcore.Field {
 
 func EventCodeField(c int) zapcore.Field {
 	return zap.Int(eventCodeKey, c)
-}
-
-func ContextField() zapcore.Field {
-	return zap.String(contextKey, contextName)
 }
 
 type SourceLocation struct {

--- a/logger.go
+++ b/logger.go
@@ -18,8 +18,12 @@ func init() {
 	fallbackLogger = logger.Sugar()
 }
 
-func InitLogger(cores ...zapcore.Core) {
-	fallbackLogger = zap.New(zapcore.NewTee(cores...), zap.AddCaller()).Sugar()
+func SetDefaultLogger(zl *zap.SugaredLogger) {
+	fallbackLogger = zl
+}
+
+func NewLogger(cores ...zapcore.Core) *zap.SugaredLogger {
+	return zap.New(zapcore.NewTee(cores...), zap.AddCaller()).Sugar()
 }
 
 func NewPreparedStdoutCore(level string) zapcore.Core {
@@ -47,7 +51,7 @@ func parseLogLevel(level string) zapcore.Level {
 
 func NewPreparedDeviceCore(level string, ws zapcore.WriteSyncer) zapcore.Core {
 	return newDeviceEventCore(
-		newDeviceEventEncoder(newDeviceEventEncoderConfig()), 
+		zapcore.NewJSONEncoder(newDeviceEventEncoderConfig()), 
 		ws, 
 		levelEnabler(level),
 	)


### PR DESCRIPTION
- adding SetDefaultLogger func
- context field is filled as logger name
- remove unused fields